### PR TITLE
Output destination can be dynamically determined from the task

### DIFF
--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -11,7 +11,7 @@ module Whenever
       @mailto                           = options.fetch(:mailto, :default_mailto)
       @job_template                     = options.delete(:job_template) || ":job"
       @roles                            = Array(options.delete(:roles))
-      @options[:output]                 = options.has_key?(:output) ? Whenever::Output::Redirection.new(options[:output]).to_s : ''
+      @options[:output]                 = options.has_key?(:output) ? Whenever::Output::Redirection.new(options[:output], options[:task]).to_s : ''
       @options[:environment_variable] ||= "RAILS_ENV"
       @options[:environment]          ||= :production
       @options[:path]                   = Shellwords.shellescape(@options[:path] || Whenever.path)

--- a/lib/whenever/output_redirection.rb
+++ b/lib/whenever/output_redirection.rb
@@ -1,8 +1,9 @@
 module Whenever
   module Output
     class Redirection
-      def initialize(output)
+      def initialize(output, task)
         @output = output
+        @task = task
       end
       
       def to_s
@@ -11,7 +12,7 @@ module Whenever
           when String   then redirect_from_string
           when Hash     then redirect_from_hash
           when NilClass then ">> /dev/null 2>&1"
-          when Proc     then @output.call
+          when Proc     then @output.lambda? ? @output.call : @output.call(@task)
           else ''
         end 
       end

--- a/test/functional/output_redirection_test.rb
+++ b/test/functional/output_redirection_test.rb
@@ -245,4 +245,20 @@ class OutputRedirectionTest < Whenever::TestCase
 
     assert_match(/^.+ .+ .+ .+ blahblah 2>&1 | logger -t whenever_cron$/, output)
   end
+
+  test 'a command when the standard output is set to a proc' do
+    output = Whenever.cron \
+    <<-file
+      # :output must be escaped so that eval can be executed
+      set :job_template, nil
+      set :output, proc { |task| "2>&1 | " + task.sub(/\\..+$/, '') + ".log" }
+      every 2.hours do
+        command "/path/to/file_a.rb"
+        command "/path/to/file_b"
+      end
+    file
+
+    assert_match(%r{^.+ .+ .+ .+ /path/to/file_a.rb 2>&1 | /path/to/file_a.log$}, output)
+    assert_match(%r{^.+ .+ .+ .+ /path/to/file_b 2>&1 | /path/to/file_b.log$}, output)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,13 @@
 require 'whenever'
 require 'test_case'
-require 'mocha/setup'
+
+begin
+  require 'mocha/setup'
+rescue LoadError => e
+  raise unless e.message =~ %r{mocha/setup}
+
+  require 'mocha/minitest'
+end
 
 module Whenever::TestHelpers
   protected


### PR DESCRIPTION
I want different tasks to output to different logs.
Different tasks should output to different logs.
Currently, we have to write :output for each task, which is not DRY.
Since :output can be written dynamically, we can change the output destination dynamically by passing tasks to it.

However, since lambda requires an argument, changing it will break the existing code.
On the other hand, proc works without arguments, so we can use tasks as arguments only for proc to maintain backward compatibility.